### PR TITLE
Feature/parameterize unsupported environments

### DIFF
--- a/bin/runbackup.pl
+++ b/bin/runbackup.pl
@@ -179,6 +179,7 @@ push @params, "-l", "debug" if ($loglevel == 7);
 push @params, "-m", "minimal" if ($loglevel <= 5);
 push @params, "-m", "detailed" if ($loglevel > 5);
 push @params, "-v" if ($loglevel == 7);
+push @params, "--unsupportedEnvironment" if is_enabled($p{'CONFIG.UNSUPPORTED_ENVIORNMENT'});
 
 push @params, $dest;
 
@@ -351,7 +352,7 @@ sub formatSize {
 
         return wantarray ? ($size, $units->[$exp]) : sprintf("%.2f %s", $size, $units->[$exp]);
     }
-	
+
 
 sub is_mountpoint {
 	

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -178,7 +178,7 @@
 	$( "#NOTIFY_BACKUP_ERRORS" ).change(function(){change_config('CONFIG.NOTIFY_BACKUP_ERRORS', $(this)[0].checked)});
 	$( "[name='email_notification']" ).change(function(){change_config('CONFIG.EMAIL_NOTIFICATION', $(this)[0].checked)});
 	$( "#stop_services" ).change(function(){change_config('CONFIG.STOPSERVICES', $(this).val().replace(/(?:\r\n|\r|\n)/g, ','))});
-
+	$( "#UNSUPPORTED_ENVIORNMENT" ).change(function(){change_config('CONFIG.UNSUPPORTED_ENVIORNMENT', $(this)[0].checked)});
 
 	// Get numbers of raspiBackup PIDs every 5 seconds and update submit button status
 	setInterval(function() {

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -47,6 +47,9 @@
 
 	</style>
 
+	<p class="wide"><TMPL_VAR BACKUP.HEADER_RASPIBACKUP_OPTIONS></p>
+		<input type="checkbox" name="UNSUPPORTED_ENVIORNMENT" id="UNSUPPORTED_ENVIORNMENT" class="NOTIFY" <TMPL_VAR UNSUPPORTED_ENVIORNMENT>><label for="UNSUPPORTED_ENVIORNMENT"><TMPL_VAR BACKUP.UNSUPPORTED_ENVIORNMENT></label>
+
 	<p  class="wide"><TMPL_VAR BACKUP.HEADER_TIMETABLE></p>
 	<table class="ui-widget" style="border-collapse:collapse;"  border="1" width="95%">
 	<!--

--- a/templates/lang/language_cs.ini
+++ b/templates/lang/language_cs.ini
@@ -44,3 +44,5 @@ HINT_STOP_START_SERVICES="Zastavení a spuštění služeb je užitečné pro ko
 HINT_DEST_DOES_NOT_EXIST="Adresář neexistuje (ale hodnota byla uložena)."
 OPTION_INFOS="Při úspěchu"
 OPTION_ERRORS="Při chybě"
+HEADER_RASPIBACKUP_OPTIONS="možnosti raspiBackup"
+UNSUPPORTED_ENVIORNMENT="přidat --unsupportedEnvironment"

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -47,3 +47,5 @@ HINT_DEST_DOES_NOT_EXIST="Verzeichnis existiert nicht (es wurde trotzdem gespeic
 HINT_NOT_AN_EXTERNAL_DEVICE="Ziel ist kein externer Datenträger. Es kann nicht auf sich selbst gesichert werden. "
 OPTION_INFOS="Bei Erfolg"
 OPTION_ERRORS="Bei Fehlern"
+HEADER_RASPIBACKUP_OPTIONS="raspiBackup Optionen"
+UNSUPPORTED_ENVIORNMENT="führe aus mit --unsupportedEnvironment"

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -45,3 +45,5 @@ HINT_DEST_DOES_NOT_EXIST="Directory does not exist (but value was saved)."
 HINT_NOT_AN_EXTERNAL_DEVICE="Destination is not an external device. Cannot backup to itself. "
 OPTION_INFOS=On Success
 OPTION_ERRORS=Or Error
+HEADER_RASPIBACKUP_OPTIONS="raspiBackup options"
+UNSUPPORTED_ENVIORNMENT="add --unsupportedEnvironment"

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -295,6 +295,12 @@ if (is_enabled($p->{"CONFIG.NOTIFY_BACKUP_ERRORS"})) {
 	$maintemplate->param("NOTIFY_BACKUP_ERRORS", '');
 }
 
+if (is_enabled($p->{"CONFIG.UNSUPPORTED_ENVIORNMENT"})) {
+	$maintemplate->param("UNSUPPORTED_ENVIORNMENT", 'checked="checked"');
+} else {
+	$maintemplate->param("UNSUPPORTED_ENVIORNMENT", '');
+}
+
 my $email_notification_html = checkbox(-name => 'email_notification',
 								  -checked => is_enabled($p->{'CONFIG.EMAIL_NOTIFICATION'}),
 									-value => 1,


### PR DESCRIPTION
as suggested in #38 here an adjusted version of the plugin that saves a new config option "UNSUPPORTED_ENVIORNMENT" that can be set via a checkbox in the frontend.
I tried it on my installation and it seems to be working fine.
without the new checkbox it fails as also has been the case before:
![image](https://user-images.githubusercontent.com/1442745/229352665-4847aafe-d6e1-4db8-9ae0-2443e40dc6bc.png)
![image](https://user-images.githubusercontent.com/1442745/229352723-73debb49-ba99-4520-925b-ddd192182d8f.png)

when i set the new checbkox the backup runs without problems 🤘 
![image](https://user-images.githubusercontent.com/1442745/229355217-0960c371-eb7f-4040-b63d-0e34f3ed6c84.png)


Disclaimer: i am not a perl/cgi developer. In fact that's the first time a touched that technology 😆 But i made my way throgh looking at the other parameters and settings so hopefully i didn't bypass any best practices etc.